### PR TITLE
Change shutil.copy to shutil.copy2

### DIFF
--- a/steam_screenshot_tool.py
+++ b/steam_screenshot_tool.py
@@ -78,7 +78,7 @@ def run_script():
                                     shutil.move(file_path, destination_file)
                                     log_text.insert(tk.END, f"Moved {file_name} to {new_screenshots_folder}\n")
                                 else:
-                                    shutil.copy(file_path, destination_file)
+                                    shutil.copy2(file_path, destination_file)
                                     log_text.insert(tk.END, f"Copied {file_name} to {new_screenshots_folder}\n")
                             else:
                                 log_text.insert(tk.END, f"Skipping non-file {file_name}\n")


### PR DESCRIPTION
copy2 attempts to preserve file metadata, saving for example the date the screenshot was taken in the metadata.

https://stackoverflow.com/questions/17685217/keeping-file-attributes-on-a-copy